### PR TITLE
[BIOMAGE-2341] Retrying authenticate on 401 for fetch_api

### DIFF
--- a/biomage_programmatic_interface/connection.py
+++ b/biomage_programmatic_interface/connection.py
@@ -1,18 +1,24 @@
+import backoff
 import boto3
 import requests
 
 import biomage_programmatic_interface.exceptions as exceptions
 from biomage_programmatic_interface.experiment import Experiment
 
+HTTP_METHODS = {"POST": requests.post, "PATCH": requests.patch, "GET": requests.get}
+
 
 class Connection:
     def __init__(self, username, password, instance_url, verbose=True):
         self.verbose = verbose
         self.__api_url = self.__get_api_url(instance_url)
+        self.username = username
+        self.password = password
+        self.instance_url = instance_url
         cognito_params = self.__get_cognito_params().json()
-        clientId = cognito_params["clientId"]
-        region = cognito_params["clientRegion"]
-        self.__authenticate(username, password, clientId, region)
+        self.clientId = cognito_params["clientId"]
+        self.region = cognito_params["clientRegion"]
+        self.__authenticate()
 
     def __get_cognito_params(self):
         try:
@@ -20,14 +26,14 @@ class Connection:
         except Exception:
             raise exceptions.InstanceNotFound() from None
 
-    def __authenticate(self, username, password, clientId, region):
-        client = boto3.client("cognito-idp", region_name=region)
+    def __authenticate(self):
+        client = boto3.client("cognito-idp", region_name=self.region)
 
         try:
             resp = client.initiate_auth(
-                ClientId=clientId,
+                ClientId=self.clientId,
                 AuthFlow="USER_PASSWORD_AUTH",
-                AuthParameters={"USERNAME": username, "PASSWORD": password},
+                AuthParameters={"USERNAME": self.username, "PASSWORD": self.password},
             )
         except Exception:
             raise exceptions.IncorrectCredentials() from None
@@ -43,15 +49,31 @@ class Connection:
             return instance_url
         return f"https://api.{instance_url}/"
 
+    @backoff.on_exception(
+        backoff.constant,
+        requests.exceptions.HTTPError,
+        max_tries=3,
+        jitter=backoff.full_jitter,
+    )
     def fetch_api(self, url, body, method="POST"):
-        methods = {"POST": requests.post, "PATCH": requests.patch}
-
         headers = {
             "Authorization": "Bearer " + self.__jwt,
             "Content-Type": "application/json",
         }
 
-        return methods[method](self.__api_url + url, json=body, headers=headers)
+        response = HTTP_METHODS[method](
+            self.__api_url + url, json=body, headers=headers
+        )
+
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            if response.status_code == 401:
+                print("fetch_api: refresh expired token")
+                self.__authenticate()
+            raise e
+
+        return response
 
     def uploadS3(self, objectS3, signed_url, compress=True):
         if compress and not objectS3.is_compressed():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 boto3==1.24.89
 requests==2.28.1
+backoff==1.10.0


### PR DESCRIPTION
After an hour the JWT token expires making the requests like `upload_samples` fail. I've added an automatic token refresh if we get any 401 error.

https://biomage.atlassian.net/browse/BIOMAGE-2341